### PR TITLE
feat: add artifactHash and prevArtifactHash fields to content schema

### DIFF
--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -534,7 +534,8 @@ content.copy.props_to_remove=["downloadUrl", "artifactUrl", "variants",
                                "LastPublishedBy", "rejectReasons", "rejectComment", "gradeLevel", "subject",
                                "medium", "board", "topic", "purpose", "subtopic", "contentCredits",
                                "owner", "collaborators", "creators", "contributors", "badgeAssertions", "dialcodes",
-                               "concepts", "keywords", "reservedDialcodes", "dialcodeRequired", "leafNodes", "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus", "lastPublishedBy", "streamingUrl"]
+                               "concepts", "keywords", "reservedDialcodes", "dialcodeRequired", "leafNodes", "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus", "lastPublishedBy", "streamingUrl",
+                               "artifactHash", "prevArtifactHash"]
 
 content.copy.origin_data=["name", "author", "license", "organisation"]
 

--- a/knowlg-service/conf/application.conf
+++ b/knowlg-service/conf/application.conf
@@ -604,7 +604,8 @@ content.copy.props_to_remove=["downloadUrl", "artifactUrl", "variants",
                                "LastPublishedBy", "rejectReasons", "rejectComment", "gradeLevel", "subject",
                                "medium", "board", "topic", "purpose", "subtopic", "contentCredits",
                                "owner", "collaborators", "creators", "contributors", "badgeAssertions", "dialcodes",
-                               "concepts", "keywords", "reservedDialcodes", "dialcodeRequired", "leafNodes", "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus", "lastPublishedBy", "streamingUrl"]
+                               "concepts", "keywords", "reservedDialcodes", "dialcodeRequired", "leafNodes", "sYS_INTERNAL_LAST_UPDATED_ON", "prevStatus", "lastPublishedBy", "streamingUrl",
+                               "artifactHash", "prevArtifactHash"]
 
 content.copy.origin_data=["name", "author", "license", "organisation"]
 

--- a/schemas/content/1.0/config.json
+++ b/schemas/content/1.0/config.json
@@ -6,7 +6,7 @@
         "copy" : [
             "status"
         ],
-        "update": []
+        "update": ["artifactUrl", "size", "artifactHash", "prevArtifactHash"]
     },
     "objectType": "Content",
     "external": {

--- a/schemas/content/1.0/config.json
+++ b/schemas/content/1.0/config.json
@@ -6,7 +6,7 @@
         "copy" : [
             "status"
         ],
-        "update": ["artifactUrl", "size", "artifactHash", "prevArtifactHash"]
+        "update": ["artifactHash", "prevArtifactHash"]
     },
     "objectType": "Content",
     "external": {

--- a/schemas/content/1.0/schema.json
+++ b/schemas/content/1.0/schema.json
@@ -298,6 +298,14 @@
       "type": "string",
       "format": "url"
     },
+    "artifactHash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "prevArtifactHash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
     "previewUrl": {
       "type": "string",
       "format": "url"


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.12, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content records now support optional artifact integrity hashes.
  * Artifact hashes must use a valid 64-character lowercase hexadecimal format.

* **Improvements**
  * Content update operations can now copy artifact URLs, sizes, and artifact hash values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->